### PR TITLE
Add tests and bilingual README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,63 @@
-# 灵境孪生中台
+# 灵境孪生中台 / Virtual Twin Data Platform
 
 “灵境孪生中台”是面向数字孪生场景的数据服务平台，致力于为数字孪生管理和应用提供统一、标准化、多源异构数据的整合与服务能力。平台支持多种工业数据类型的接入、转换、存储、管理与分发，助力数字孪生场景的快速构建与高效运维。
 
-## 项目目标
+The **Virtual Twin Data Platform** is a data service solution for digital twin scenarios. It provides unified and standardized access, transformation, storage and distribution for heterogeneous industrial data sources. The platform helps quickly build and operate digital twin projects by supporting a variety of industrial data types.
+
+## 项目目标 / Project Goals
 
 为数字孪生场景和客户端提供统一的数据服务，整合3D模型、IoT、视频流、GIS、附件等多源异构数据，实现数据标准化、统一管理和灵活绑定，支撑数字孪生场景的构建、可视化和智能化。
 
-## 支持的数据类型
+Provide unified data services for digital twin scenes and clients. It integrates 3D models, IoT, video streams, GIS data and attachments into a standardized repository that can be flexibly bound to scenes for visualization and intelligent analysis.
 
-1. **3D工业模型数据**
+## 支持的数据类型 / Supported Data Types
+
+1. **3D工业模型数据 / 3D Industrial Models**
    - 支持多种3D工业模型格式，统一转换为GLB或FBX格式存储。
    - 元数据（如模型描述、结构、标签等）单独抽离存储于MongoDB。
    - 转换后的模型作为数字孪生场景的基础素材，可实例化为模型实例。
 
-2. **模型实例与场景**
+   The platform converts various industrial model formats to GLB or FBX. Metadata such as descriptions, structure and tags are stored separately in MongoDB. The converted models can then be instantiated in scenes.
+
+2. **模型实例与场景 / Model Instances and Scenes**
    - 支持对基础模型进行实例化，形成模型实例。
    - 模型实例作为数字孪生数据的载体，组成场景结构。
 
-3. **IoT数据**
+   Base models can be instantiated to become model instances. Scenes are composed of these instances and serve as carriers for digital twin data.
+
+3. **IoT数据 / IoT Data**
    - 支持用户自定义输入MQTT数据源，通过连接池管理。
    - 平台自动订阅、实时缓存于Redis，并持久化至MongoDB。
    - 用户可查阅历史与实时MQTT数据，并可将订阅对象绑定到模型实例。
 
-4. **附件数据**
+   Custom MQTT data sources can be added and managed with connection pools. Data is subscribed automatically, cached in Redis and persisted to MongoDB for history queries. MQTT topics can be bound to model instances.
+
+4. **附件数据 / Attachments**
    - 使用MinIO进行对象存储，支持各类附件上传。
    - 可将MinIO对象链接绑定到模型实例。
 
-5. **视频流数据**
+   Files are stored in MinIO object storage and can be linked to model instances.
+
+5. **视频流数据 / Video Streams**
    - 支持多种实时视频流（如HLS、RTSP、海康SDK等）。
    - 视频流信息存储于MongoDB，通过平台统一转为标准接口（可扩展）。
    - 支持流送服务（不做视频存储），可绑定到模型实例。
 
-6. **GIS数据**
+   Multiple live stream formats (HLS, RTSP, SDKs) are supported. Stream information is stored in MongoDB and exposed through unified APIs. Streams can be bound to instances without storing the video.
+
+6. **GIS数据 / GIS Data**
    - 支持3DTiles数据上传，并可转换为TMS、WMS、WTMS等服务。
    - GIS数据可绑定到数字孪生场景。
 
-7. **数据可视化**
+   3DTiles uploads are supported and can be converted to TMS/WMS/WTMS services. GIS data can be bound to scenes.
+
+7. **数据可视化 / Data Visualization**
    - 集成GoView数据可视化编辑工具，支持拖拽生成可视化报表。
    - 可视化报表可绑定并叠加到场景中。
 
-## 平台特性
+   The GoView visualization editor is integrated so reports can be built via drag‑and‑drop and overlaid in scenes.
+
+## 平台特性 / Features
 
 - 多源异构数据标准化与统一管理
 - 灵活的数据绑定与场景构建能力
@@ -51,7 +69,9 @@
 - Docker化部署，支持多种数据库组合
 - 默认数据环境：MongoDB、Redis、MinIO
 
-## 系统架构
+Standardized management for heterogeneous data, flexible scene binding, automatic model conversion, real-time IoT data handling, unified attachments/video/GIS access, visualization tools, web management APIs and Docker-based deployment with MongoDB, Redis and MinIO by default.
+
+## 系统架构 / System Architecture
 
 平台采用微服务与容器化架构，核心服务包括：
 - 数据接入与转换服务
@@ -60,9 +80,11 @@
 - Web管理与API服务
 - 可视化编辑与展示服务
 
-## 环境配置
+The system is built with microservices and containers. Core services include data ingestion/conversion, unified storage, real-time data and caching, web management APIs, and visualization.
 
-### 开发环境
+## 环境配置 / Environment Setup
+
+### 开发环境 / Development
 
 开发环境只启动MongoDB、Redis和MinIO服务，方便本地开发和调试：
 
@@ -76,7 +98,9 @@ docker-compose -f docker-compose.dev.yml up -d
 uvicorn app.main:app --reload
 ```
 
-### 生产环境
+Only MongoDB, Redis and MinIO are started in development. Use the above commands to run the services and start the server with hot reload.
+
+### 生产环境 / Production
 
 生产环境使用完整的Docker配置，包含所有服务：
 
@@ -85,24 +109,27 @@ uvicorn app.main:app --reload
 docker-compose -f docker-compose.prod.yml up -d
 ```
 
-## 服务访问
+## 服务访问 / Service Endpoints
 
 - Web管理端: http://localhost:8000
 - MinIO控制台: http://localhost:9001
 - MongoDB: localhost:27017
 - Redis: localhost:6379
 
-## 配置文件
+Access the management UI at `http://localhost:8000`. MinIO console runs on `http://localhost:9001`. MongoDB and Redis are available on the listed ports.
 
-系统使用YAML格式的配置文件（config.yaml）来管理所有配置项，包括：
+## 配置文件 / Configuration File
 
+系统使用YAML格式的配置文件（`config.yaml`）来管理所有配置项，包括：
 - MongoDB配置
 - Redis配置
 - MinIO配置
 - JWT配置
 - 支持的数据类型与格式配置
 
-## 环境变量
+All configuration is stored in a `config.yaml` file, covering MongoDB, Redis, MinIO, JWT and supported data formats.
+
+## 环境变量 / Environment Variables
 
 - MONGO_URL: MongoDB连接URL
 - REDIS_URL: Redis连接URL
@@ -111,7 +138,7 @@ docker-compose -f docker-compose.prod.yml up -d
 - MINIO_SECRET_KEY: MinIO密钥
 - SECRET_KEY: JWT密钥（用于token生成）
 
-## 开发
+## 开发 / Development Workflow
 
 1. 安装依赖：
 ```bash
@@ -126,4 +153,5 @@ docker-compose -f docker-compose.dev.yml up -d
 3. 运行开发服务器：
 ```bash
 uvicorn app.main:app --reload
-``` 
+```
+

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -1,0 +1,58 @@
+import unittest
+import os
+import types
+import sys
+from importlib import reload
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+SITE_PACKAGES = os.path.join(ROOT_DIR, '.venv', 'lib', 'python3.11', 'site-packages')
+if os.path.isdir(SITE_PACKAGES):
+    sys.path.insert(0, SITE_PACKAGES)
+
+# Stub jose module since dependency is not available
+jose_module = types.ModuleType("jose")
+class DummyJWTError(Exception):
+    pass
+jwt_submodule = types.ModuleType("jwt")
+
+def encode(payload, key, algorithm=None):
+    import base64, json, datetime
+    def default(o):
+        if isinstance(o, (datetime.datetime, datetime.date)):
+            return o.isoformat()
+        raise TypeError
+    return base64.b64encode(json.dumps(payload, default=default).encode()).decode()
+
+def decode(token, key, algorithms=None):
+    import base64, json
+    return json.loads(base64.b64decode(token).decode())
+
+jwt_submodule.encode = encode
+jwt_submodule.decode = decode
+jose_module.JWTError = DummyJWTError
+jose_module.jwt = jwt_submodule
+sys.modules.setdefault("jose", jose_module)
+
+# Environment variables for utils
+os.environ["JWT_SECRET_KEY"] = "testsecret"
+os.environ["JWT_ALGORITHM"] = "HS256"
+os.environ["JWT_ACCESS_TOKEN_EXPIRE_MINUTES"] = "30"
+os.environ["MONGO_USERNAME"] = "user"
+os.environ["MONGO_PASSWORD"] = "pass"
+os.environ["MONGO_HOST"] = "localhost"
+os.environ["MONGO_PORT"] = "27017"
+os.environ["MONGO_DB_NAME"] = "db"
+
+import app.auth.utils as utils
+utils = reload(utils)
+
+class AuthUtilsTestCase(unittest.TestCase):
+    def test_create_access_token(self):
+        token = utils.create_access_token({"sub": "tester"})
+        payload = utils.jwt.decode(
+            token, utils.SECRET_KEY, algorithms=[utils.ALGORITHM]
+        )
+        self.assertEqual(payload["sub"], "tester")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mongo_init.py
+++ b/tests/test_mongo_init.py
@@ -1,0 +1,38 @@
+import unittest
+import os
+import types
+import sys
+from importlib import reload
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+SITE_PACKAGES = os.path.join(ROOT_DIR, '.venv', 'lib', 'python3.11', 'site-packages')
+if os.path.isdir(SITE_PACKAGES):
+    sys.path.insert(0, SITE_PACKAGES)
+
+os.environ["MONGO_USERNAME"] = "user"
+os.environ["MONGO_PASSWORD"] = "pass"
+os.environ["MONGO_HOST"] = "localhost"
+os.environ["MONGO_PORT"] = "27017"
+os.environ["MONGO_DB_NAME"] = "testdb"
+
+# Mock motor.motor_asyncio so the module can be imported without the dependency
+motor_module = types.ModuleType("motor")
+motor_asyncio = types.ModuleType("motor.motor_asyncio")
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+motor_asyncio.AsyncIOMotorClient = DummyClient
+setattr(motor_module, "motor_asyncio", motor_asyncio)
+sys.modules.setdefault("motor", motor_module)
+sys.modules.setdefault("motor.motor_asyncio", motor_asyncio)
+
+from app.utils import mongo_init
+mongo_init = reload(mongo_init)
+
+class MongoInitTestCase(unittest.TestCase):
+    def test_get_mongo_url(self):
+        expected = "mongodb://user:pass@localhost:27017/testdb?authSource=admin"
+        self.assertEqual(mongo_init.get_mongo_url(), expected)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- convert README to a bilingual Chinese/English version
- add unit tests for auth utilities and Mongo URL builder

## Testing
- `python -m unittest discover -s tests`